### PR TITLE
fix: add always run to support run without variables changed

### DIFF
--- a/kaniko/plan_modifier.go
+++ b/kaniko/plan_modifier.go
@@ -2,51 +2,45 @@ package kaniko
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"github.com/seal-io/terraform-provider-kaniko/utils"
 )
 
-// RandomModifier returns a plan modifier set a random string to the planned value.
-// Use this when need to generate different plan.
-func RandomModifier() planmodifier.String {
-	return randomModifier{}
+// BuildIDModifier returns a plan modifier set build id to unknown string to the planned value.
+func BuildIDModifier() planmodifier.String {
+	return buildIDModifier{}
 }
 
-// randomModifier implements the plan modifier.
-type randomModifier struct{}
+// buildIDModifier implements the plan modifier.
+type buildIDModifier struct{}
 
 // Description returns a human-readable description of the plan modifier.
-func (m randomModifier) Description(_ context.Context) string {
-	return "Generate random string value for every plan."
+func (m buildIDModifier) Description(_ context.Context) string {
+	return "Set build id to unknown string while need always run for every plan."
 }
 
 // MarkdownDescription returns a markdown description of the plan modifier.
-func (m randomModifier) MarkdownDescription(_ context.Context) string {
-	return "Generate random string value for every plan."
+func (m buildIDModifier) MarkdownDescription(_ context.Context) string {
+	return "Set build id to unknown string while need always run for every plan."
 }
 
 // PlanModifyString implements the plan modification logic.
-func (m randomModifier) PlanModifyString(
+func (m buildIDModifier) PlanModifyString(
 	_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse,
 ) {
-	switch {
-	case !req.PlanValue.IsNull() && req.StateValue.IsNull():
-		// For create, skip if there is a plan value and state value is null.
-		return
-	case !req.PlanValue.IsNull() && !req.StateValue.IsNull() && req.PlanValue != req.StateValue:
-		// For update, skip if there is a plan value, and it is not equal to state value.
-		return
-	default:
-		// For update, set a random string to the planned value to change the plan.
-		id := types.StringValue(fmt.Sprintf("kaniko-%s", utils.String(8)))
-		req.PlanValue = id
-		req.StateValue = id
+	var (
+		ctx  = context.Background()
+		plan imageResourceModel
+	)
 
-		resp.PlanValue = id
-		resp.RequiresReplace = true
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.AlwaysRun.IsNull() && plan.AlwaysRun.ValueBool() {
+		resp.PlanValue = types.StringUnknown()
 	}
 }


### PR DESCRIPTION
**Problem**

Previous use `PlanModifyString` to update `id` to a random string with some conditions to support running without variables changed may cause incorrect updates

**Solution**

Add always run config to support running without variables changed.

**Issue**

https://github.com/seal-io/walrus/issues/998

